### PR TITLE
fix: correct posts URL

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,14 +16,17 @@ const sortedPosts = allPosts.sort((a, b) => {
     記事一覧
   </h1>
   <ul>
-    {sortedPosts.map((post) => (
-      <li class="list">
-        <a href={`/posts/${post.slug}/`}>{post.data.title}</a>
-        <div>
-          <small>{post.data.date}</small>
-        </div>
-      </li>
-    ))}
+    {sortedPosts.map((post) => {
+      const urlPath = post.id.replace(/\.(md|mdx)$/, '');
+      return (
+        <li class="list">
+          <a href={`/posts/${urlPath}/`}>{post.data.title}</a>
+          <div>
+            <small>{post.data.date}</small>
+          </div>
+        </li>
+      );
+    })}
   </ul>
 </Layout>
 

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -5,10 +5,13 @@ import Layout from '../../layouts/Layout.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
-  return posts.map((post) => ({
-    params: { slug: post.slug },
-    props: { post },
-  }));
+  return posts.map((post) => {
+    const urlPath = post.id.replace(/\.(md|mdx)$/, '');
+    return {
+      params: { slug: urlPath },
+      props: { post },
+    };
+  });
 }
 
 type Props = {
@@ -18,6 +21,8 @@ type Props = {
 const { post } = Astro.props;
 const { Content } = await post.render();
 
+const urlPath = post.id.replace(/\.(md|mdx)$/, '');
+
 // GitHub履歴URL
 const historyUrl = `https://github.com/sakait-pc/sakait-blog/commits/main/src/content/posts/${post.id}`;
 ---
@@ -26,7 +31,7 @@ const historyUrl = `https://github.com/sakait-pc/sakait-blog/commits/main/src/co
   <article>
     <header>
       <h1 class="entry-title">
-        <a href={`/posts/${post.slug}/`} class="entry-title-link">{post.data.title}</a>
+        <a href={`/posts/${urlPath}/`} class="entry-title-link">{post.data.title}</a>
       </h1>
       <div>
         <div><small>Date: {post.data.date}</small></div>


### PR DESCRIPTION
- `post.slug`だとフォルダ名が小文字に変換され内部リンクをクリックすると404に なる問題を修正した。`post.id`を使用することで解決した。

## 概要
このプルリクエストは、サイト全体でブログ投稿のURLの生成方法と参照方法を更新し、一貫性を確保し、URLからファイル拡張子を削除します。変更は投稿一覧ページと個別の投稿ページの両方に影響します。

**URLハンドリングの改善:**

* index.astroでは、投稿一覧が`post.id`から`.md`と`.mdx`のファイル拡張子を削除することでURLを生成し、各投稿のリンクをよりクリーンにします。
* 投稿の静的パスが生のスラッグの代わりにクリーンアップされた`urlPath`を使用して生成され、ルーティングが新しいURL構造に合わせられます。
* 個別の投稿ページでは、投稿への内部リンクがすべてクリーンアップされた`urlPath`を使用し、ナビゲーションの一貫性を確保し、URLにファイル拡張子が表示される問題を防ぎます。